### PR TITLE
WORKAROUND: unzip may be set to "" on some Linux systems

### DIFF
--- a/R/decompress.R
+++ b/R/decompress.R
@@ -75,7 +75,7 @@ getrootdir <- function(file_list) {
 }
 
 my_unzip <- function(src, target, unzip = getOption("unzip")) {
-  if (unzip == "internal") {
+  if (unzip %in% c("internal", "")) {
     return(utils::unzip(src, exdir = target))
   }
 


### PR DESCRIPTION
unzip may be set to "" on some Linux systems, which causes `remotes::install_remote()` to generate an obscure error that is a bit tedious to troubleshoot:
```r
Error in system_check(unzip, args) :
  Command  failed sh: : command not found
```
Since "internal" unzip always, work this patch makes sure that is
used also when unzip is "".

See https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17255 for
more details on why unzip may become "".

PS. Yes, one could force `options(unzip = "internal")` on such systems, and ideally `utils:::.onLoad()` should do that, but until then this is user friendly patch.